### PR TITLE
Integrate backend into main CopCore

### DIFF
--- a/base/inc/CopCore/CMakeLists.txt
+++ b/base/inc/CopCore/CMakeLists.txt
@@ -5,17 +5,16 @@ cmake_minimum_required(VERSION 3.18)
 project(CopCore VERSION 0.1.0)
 
 include(GNUInstallDirs)
+include(CTest)
 
 # ---------------------
 # Device Target Options:
-# These should really be set from the external project
+# These can be set from the external project (Namespaced?)
 # ---------------------
-
 # Device target architecture
 set(TARGET_DEVICE CPU CACHE STRING "Target architecture of the device")
 set_property(CACHE TARGET_DEVICE PROPERTY STRINGS CPU CUDA HIP CUDACLANG)
 set(TARGET_DEFINITION "TARGET_DEVICE_${TARGET_DEVICE}")
-add_compile_definitions(${TARGET_DEFINITION})
 
 # CPU manual vectorization target
 set(CPU_STATIC_VECTOR_WIDTH OFF CACHE STRING "Define a static vector width for CPU target")
@@ -26,11 +25,30 @@ set(CUDA_ARCH COMPATIBILITY CACHE STRING "CUDA target architecture")
 set_property(CACHE CUDA_ARCH PROPERTY STRINGS COMPATIBILITY MAX MIN 53 60 61 62 70 72 75)
 
 # -----
+# Dependencies
+if(TARGET_DEVICE STREQUAL "CUDA")
+  enable_language(CUDA)
+endif()
 
 # Core library
-add_library(CopCore INTERFACE)
-target_compile_features(CopCore INTERFACE cxx_std_17)
-target_include_directories(CopCore INTERFACE
+add_library(CopCore STATIC
+  include/CopCore/backend/BackendCommon.h
+  include/CopCore/backend/CPUBackend.h
+  include/CopCore/backend/CPUID.h
+  include/CopCore/backend/CUDABackend.h
+  include/CopCore/backend/HIPBackend.h
+  include/CopCore/backend/Vector.h
+  include/CopCore/CopCore.h
+  include/CopCore/LoggerCommon.h
+  include/CopCore/Logger.h
+  include/CopCore/TupleTools.cuh
+  src/backend/CPUBackend.cpp
+  src/backend/CPUID.cpp
+  src/backend/HalfType.cpp
+  src/backend/Utils.cpp)
+target_compile_features(CopCore PUBLIC cxx_std_17 $<$<STREQUAL:"${TARGET_DEVICE}","CUDA">:cuda_std_17>)
+target_compile_definitions(CopCore PUBLIC ${TARGET_DEFINITION})
+target_include_directories(CopCore PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -44,16 +62,7 @@ install(TARGETS CopCore EXPORT CopCoreTargets)
 # Support files
 include(CMakePackageConfigHelpers)
 
-# -------------------
-# Add backend library
-# -------------------
-file(GLOB backend_sources "src/backend/*.cpp")
-add_library(copcore_backend ${backend_sources})
-target_include_directories(copcore_backend PUBLIC "${PROJECT_SOURCE_DIR}/include")
-target_compile_features(copcore_backend PUBLIC cxx_std_17)
-install(TARGETS copcore_backend)
-
-
+# Support files
 write_basic_package_version_file("${PROJECT_BINARY_DIR}/CopCoreConfigVersion.cmake"
   COMPATIBILITY AnyNewerVersion
   ARCH_INDEPENDENT)

--- a/base/inc/CopCore/include/CopCore/CopCore.h
+++ b/base/inc/CopCore/include/CopCore/CopCore.h
@@ -9,4 +9,6 @@
 #ifndef COPCORE_COPCORE_H_
 #define COPCORE_COPCORE_H_
 
+#include "backend/BackendCommon.h"
+
 #endif // COPCORE_COPCORE_H_


### PR DESCRIPTION
Here's the minor tune up to the main CopCore build for the Allen backend you've brought in. Nothing spectacular, just adding `cuda_std_17` to the compile features to enforce this, plus build of the backend files into libCopCore. I think we have to do that as compilation hard codes in the backend, though we could have one lib per backend should it become needed.

I haven't put the test/saxpy example in yet to keep things simple - will do that in a separate PR!