### PR TITLE
First go at "Allen style" kernel

### DIFF
--- a/base/inc/CopCore/CMakeLists.txt
+++ b/base/inc/CopCore/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(CopCore STATIC
   include/CopCore/backend/HIPBackend.h
   include/CopCore/backend/Vector.h
   include/CopCore/CopCore.h
+  include/CopCore/Invoke.cuh
   include/CopCore/LoggerCommon.h
   include/CopCore/Logger.h
   include/CopCore/TupleTools.cuh
@@ -58,6 +59,11 @@ add_library(CopCore::CopCore ALIAS CopCore)
 # Install headers and target(s)
 install(DIRECTORY include/CopCore DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(TARGETS CopCore EXPORT CopCoreTargets)
+
+# Testing
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 # Support files
 include(CMakePackageConfigHelpers)

--- a/base/inc/CopCore/CMakeLists.txt
+++ b/base/inc/CopCore/CMakeLists.txt
@@ -28,6 +28,7 @@ set_property(CACHE CUDA_ARCH PROPERTY STRINGS COMPATIBILITY MAX MIN 53 60 61 62 
 # Dependencies
 if(TARGET_DEVICE STREQUAL "CUDA")
   enable_language(CUDA)
+  find_package(CUDAToolkit 11.0 REQUIRED)
 endif()
 
 # Core library
@@ -52,6 +53,7 @@ target_compile_definitions(CopCore PUBLIC ${TARGET_DEFINITION})
 target_include_directories(CopCore PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(CopCore PUBLIC $<$<STREQUAL:"${TARGET_DEVICE}","CUDA">:CUDA::cudart_static>)
 
 # Alias to assist in use as a subproject
 add_library(CopCore::CopCore ALIAS CopCore)

--- a/base/inc/CopCore/include/CopCore/Invoke.cuh
+++ b/base/inc/CopCore/include/CopCore/Invoke.cuh
@@ -1,0 +1,64 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+#pragma once
+
+#include "backend/BackendCommon.h"
+#include "Logger.h"
+
+/**
+ * @brief      Invokes a function specified by its function and arguments.
+ *
+ * @param[in]  function            The function.
+ * @param[in]  grid_dim            Number of blocks of kernel invocation.
+ * @param[in]  block_dim           Number of threads of kernel invocation.
+ * @param[in]  shared_memory_size  Shared memory size.
+ * @param      stream              The stream where the function will be run.
+ * @param[in]  arguments           The arguments of the function.
+ * @param[in]  I                   Index sequence
+ *
+ * @return     Return value of the function.
+ */
+#if defined(TARGET_DEVICE_CPU) || (defined(TARGET_DEVICE_HIP) && (defined(__HCC__) || defined(__HIP__))) || \
+  ((defined(TARGET_DEVICE_CUDA) && defined(__CUDACC__)) || (defined(TARGET_DEVICE_CUDACLANG) && defined(__CUDA__)))
+template<class Fn, class Tuple, unsigned long... I>
+void invoke_impl(
+  Fn&& function,
+  const dim3& grid_dim,
+  const dim3& block_dim,
+  cudaStream_t stream,
+  const Tuple& invoke_arguments,
+  std::index_sequence<I...>)
+{
+  // If any grid dimension component, or any block dimension component is zero,
+  // return without running.
+  if (
+    grid_dim.x == 0 || grid_dim.y == 0 || grid_dim.z == 0 || block_dim.x == 0 || block_dim.y == 0 || block_dim.z == 0) {
+    return;
+  }
+
+#if defined(TARGET_DEVICE_CPU)
+  _unused(stream);
+
+  gridDim = {grid_dim.x, grid_dim.y, grid_dim.z};
+  for (unsigned int i = 0; i < grid_dim.x; ++i) {
+    for (unsigned int j = 0; j < grid_dim.y; ++j) {
+      for (unsigned int k = 0; k < grid_dim.z; ++k) {
+        blockIdx = {i, j, k};
+        function(std::get<I>(invoke_arguments)...);
+      }
+    }
+  }
+#elif defined(TARGET_DEVICE_HIP) && (defined(__HCC__) || defined(__HIP__))
+  hipLaunchKernelGGL(function, grid_dim, block_dim, 0, stream, std::get<I>(invoke_arguments)...);
+#elif (defined(TARGET_DEVICE_CUDA) && defined(__CUDACC__)) || (defined(TARGET_DEVICE_CUDACLANG) && defined(__CUDA__))
+  function<<<grid_dim, block_dim, 0, stream>>>(std::get<I>(invoke_arguments)...);
+#endif
+}
+#else
+template<class Fn, class Tuple, unsigned long... I>
+void invoke_impl(Fn&&, const dim3&, const dim3&, cudaStream_t, const Tuple&, std::index_sequence<I...>)
+{
+  error_cout << "Global function invoked with unexpected backend.\n";
+}
+#endif

--- a/base/inc/CopCore/include/CopCore/Invoke.cuh
+++ b/base/inc/CopCore/include/CopCore/Invoke.cuh
@@ -20,20 +20,15 @@
  * @return     Return value of the function.
  */
 #if defined(TARGET_DEVICE_CPU) || (defined(TARGET_DEVICE_HIP) && (defined(__HCC__) || defined(__HIP__))) || \
-  ((defined(TARGET_DEVICE_CUDA) && defined(__CUDACC__)) || (defined(TARGET_DEVICE_CUDACLANG) && defined(__CUDA__)))
-template<class Fn, class Tuple, unsigned long... I>
-void invoke_impl(
-  Fn&& function,
-  const dim3& grid_dim,
-  const dim3& block_dim,
-  cudaStream_t stream,
-  const Tuple& invoke_arguments,
-  std::index_sequence<I...>)
+    ((defined(TARGET_DEVICE_CUDA) && defined(__CUDACC__)) || (defined(TARGET_DEVICE_CUDACLANG) && defined(__CUDA__)))
+template <class Fn, class Tuple, unsigned long... I>
+void invoke_impl(Fn &&function, const dim3 &grid_dim, const dim3 &block_dim, cudaStream_t stream,
+                 const Tuple &invoke_arguments, std::index_sequence<I...>)
 {
   // If any grid dimension component, or any block dimension component is zero,
   // return without running.
-  if (
-    grid_dim.x == 0 || grid_dim.y == 0 || grid_dim.z == 0 || block_dim.x == 0 || block_dim.y == 0 || block_dim.z == 0) {
+  if (grid_dim.x == 0 || grid_dim.y == 0 || grid_dim.z == 0 || block_dim.x == 0 || block_dim.y == 0 ||
+      block_dim.z == 0) {
     return;
   }
 
@@ -56,8 +51,8 @@ void invoke_impl(
 #endif
 }
 #else
-template<class Fn, class Tuple, unsigned long... I>
-void invoke_impl(Fn&&, const dim3&, const dim3&, cudaStream_t, const Tuple&, std::index_sequence<I...>)
+template <class Fn, class Tuple, unsigned long... I>
+void invoke_impl(Fn &&, const dim3 &, const dim3 &, cudaStream_t, const Tuple &, std::index_sequence<I...>)
 {
   error_cout << "Global function invoked with unexpected backend.\n";
 }

--- a/base/inc/CopCore/tests/CMakeLists.txt
+++ b/base/inc/CopCore/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# In Allen, there are "allen_add_..." CMake functions that wrap the
+# needed steps
+# Compile for host/device as specified
+if(TARGET_DEVICE STREQUAL "CPU")
+  # Not clear why this is needed, but results in link errors if not...
+  add_definitions("-x c++")
+  set_source_files_properties(test_saxpy.cu PROPERTIES LANGUAGE CXX)
+endif()
+
+add_executable(test_saxpy test_saxpy.cu)
+target_link_libraries(test_saxpy PRIVATE CopCore::CopCore)
+add_test(NAME test_saxpy COMMAND test_saxpy)

--- a/base/inc/CopCore/tests/test_saxpy.cu
+++ b/base/inc/CopCore/tests/test_saxpy.cu
@@ -42,7 +42,7 @@ int main()
 
   // This is the awkward part - how to set the grid/block appriopriately
   // for CPU vs GPU.
-  invoke_impl(saxpy, dim3((N+255)/256), dim3(256), cudaStream_t{}, args, indices{});
+  invoke_impl(saxpy, dim3((N + 255) / 256), dim3(256), cudaStream_t{}, args, indices{});
 
   // Check
 

--- a/base/inc/CopCore/tests/test_saxpy.cu
+++ b/base/inc/CopCore/tests/test_saxpy.cu
@@ -1,0 +1,55 @@
+#include "CopCore/CopCore.h"
+#include "CopCore/Invoke.cuh"
+#include <tuple>
+
+// Dumb saxpy kernel
+// But what invokes this, with blockIdx and so on set appropriately?
+__global__ void saxpy(int n, float a, float *x, float *y)
+{
+  // In Allen, to make kernels reproducible on CPU/GPU must use blockDim strided loop:
+  for (unsigned i = threadIdx.x; i < n; i += blockDim.x) {
+    y[i] = a * x[i] + y[i];
+  }
+}
+
+int main()
+{
+  // Can we allocate memory on CPU/GPU with common functions?
+  int N      = 1 << 20;
+  float *x   = nullptr;
+  float *y   = nullptr;
+  float *d_x = nullptr;
+  float *d_y = nullptr;
+
+  // Initialize
+  x = (float *)malloc(N * sizeof(float));
+  y = (float *)malloc(N * sizeof(float));
+  cudaMalloc((void **)&d_x, N * sizeof(float));
+  cudaMalloc((void **)&d_y, N * sizeof(float));
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1.0f;
+    y[i] = 2.0f;
+  }
+
+  cudaMemcpy(d_x, x, N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_y, y, N * sizeof(float), cudaMemcpyHostToDevice);
+
+  // Invoke
+  auto args           = std::make_tuple(N, 2.0f, d_x, d_y);
+  constexpr auto size = std::tuple_size_v<decltype(args)>;
+  using indices       = std::make_index_sequence<size>;
+
+  // This is the awkward part - how to set the grid/block appriopriately
+  // for CPU vs GPU.
+  invoke_impl(saxpy, dim3((N+255)/256), dim3(256), cudaStream_t{}, args, indices{});
+
+  // Check
+
+  // Tidy
+  cudaFree(d_x);
+  cudaFree(d_y);
+  free(x);
+  free(y);
+  return 0;
+}


### PR DESCRIPTION
Import Allen's `Invoke.cuh` header for calling/launching global functions to the relevant back end. I'm not 100% sure this is the right way, but the `GlobalFunction.cuh`, `HostFunction.cuh` bring in a lot of additional functionality (properties etc) that we might not want just yet. `Invoke` is the lowest level call, and has the relevant dispatch to loop/kernel.

Add a tests subdirectory and implement a simple saxpy example using Invoke. At present, the appropriate launch arguments for grid/block dimensions only work for GPU backend, though the kernel is written using the Allen recommendation.

TODO: understand where/how Allen decides/is configured for CPU/GPU gird/block arguments.