### PR TITLE
Use grid-stride loop for CPU/GPU compatibility

### DIFF
--- a/base/inc/CopCore/tests/CMakeLists.txt
+++ b/base/inc/CopCore/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020 CERN
+# SPDX-License-Identifier: Apache-2.0
+
 # In Allen, there are "allen_add_..." CMake functions that wrap the
 # needed steps
 # Compile for host/device as specified

--- a/base/inc/CopCore/tests/test_saxpy.cu
+++ b/base/inc/CopCore/tests/test_saxpy.cu
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
 #include "CopCore/CopCore.h"
 #include "CopCore/Invoke.cuh"
 #include <tuple>


### PR DESCRIPTION
Recommendation in Allen for CUDA kernels is to use a block-stride pattern for for loops, but this does not work for simple saxpy on CPU unless the grid is forced to have a single block. The pattern was traced to a merge request:

https://gitlab.cern.ch/lhcb/Allen/-/merge_requests/196

where the changes needed could be seen in kernels where it is used for:

- Number of events is `gridDim.x`
- Event being processed is `blockIdx.x`
- `threadIdx.x` plus the `blockDim.x` stride is used to parallelize, for example, track processing.

Thus the Allen saxpy example works because it forces the grid dimension to 1, but processes multiple "events" now using `threadIdx.x` and the `blockDim` stride to identify/process. When we add multiple blocks in the CopCore `saxpy` example, the kernel needs to be rewritten to use the grid correctly to identify the "event" to process correctly.

Update `saxpy` kernel to use the full grid-stride loop as appropriate for this case. Document the Allen MR and use of block-striding vs grid-striding. Show that grid-striding reduces to block-striding when only one block is used.

The kernel interface was also changed to put "number_of_events" as the last argument so it follows the Allen example as closely as possible.